### PR TITLE
Sync

### DIFF
--- a/main/functions.c
+++ b/main/functions.c
@@ -58,7 +58,7 @@ void send_colors_toggle(int* count, Color* current_color) {
         return;
     }
     char json_body[512];
-    if(count == -1){
+    if((*count) == -1){
         snprintf(json_body, sizeof(json_body),
         "{"
         "  \"red\": %d,"

--- a/main/functions.c
+++ b/main/functions.c
@@ -10,6 +10,7 @@
 #include "pico_http_client/pico_http_client.c"
 #include "pico_http_client/socket.c"
 #include "colors.h"
+#include <math.h> 
 
 // Buffer para resposta HTTP
 char http_response[1024];
@@ -17,37 +18,6 @@ char http_response[1024];
 // Estado dos botões (inicialmente sem mensagens)
 char button1_message[50] = "Nenhum evento no botão 1";
 char button2_message[50] = "Nenhum evento no botão 2";
-
-// Função para monitorar o estado dos botões
-void monitor_buttons() {
-    static bool button1_last_state = false;
-    static bool button2_last_state = false;
-
-    bool button1_state = !gpio_get(BUTTON1_PIN); // Botão pressionado = LOW
-    bool button2_state = !gpio_get(BUTTON2_PIN);
-
-    if (button1_state != button1_last_state) {
-        button1_last_state = button1_state;
-        if (button1_state) {
-            snprintf(button1_message, sizeof(button1_message), "Botão 1 foi pressionado!");
-            printf("Botão 1 pressionado\n");
-        } else {
-            snprintf(button1_message, sizeof(button1_message), "Botão 1 foi solto!");
-            printf("Botão 1 solto\n");
-        }
-    }
-
-    if (button2_state != button2_last_state) {
-        button2_last_state = button2_state;
-        if (button2_state) {
-            snprintf(button2_message, sizeof(button2_message), "Botão 2 foi pressionado!");
-            printf("Botão 2 pressionado\n");
-        } else {
-            snprintf(button2_message, sizeof(button2_message), "Botão 2 foi solto!");
-            printf("Botão 2 solto\n");
-        }
-    }
-}
 
 
 bool verify_connection_wifi(){
@@ -61,43 +31,6 @@ bool verify_connection_wifi(){
         printf("Endereço IP %d.%d.%d.%d\n", ip_address[0], ip_address[1], ip_address[2], ip_address[3]);
     }
 } 
-
-// Função para enviar uma requisição HTTP PUT
-void send_toggle(bool* is_on) {
-    // Tamanho para a URL
-    char url[256];  
-    snprintf(url, sizeof(url), "http://%s:%s%s", HTTP_SERVER_IP, HTTP_SERVER_PORT, HTTP_POWER);
-    printf("URL: %s\n", url);
-    http_client_t *client = new_http_client(url);
-    if (!client) {
-        printf("Erro ao criar o cliente HTTP\n");
-        return;
-    }
-    char json_body[512];
-    snprintf(json_body, sizeof(json_body),
-        "{"
-        "  \"power\": %s,"
-        "  \"toggles\": ["
-        "    { \"name\": \"White Lamp\", \"toggle\": true },"
-        "    { \"name\": \"Black Lamp\", \"toggle\": false }"
-        "  ]"
-        "}",
-        *is_on ? "true" : "false");
-    add_header(client, "Content-Type", "application/json");
-    printf("Corpo da requisição: %s\n", json_body);
-    add_post(client, json_body);
-    http_response_t response = http_request(3, client);
-
-    // Verifica a resposta do servidor
-    if (response.code >= 200 && response.code < 300) 
-        printf("Requisição PUT bem-sucedida! Código de status: %d\n", response.code);
-    else 
-        printf("Erro na requisição PUT. Código de status: %d\n", response.code);
-    // Libera os recursos alocados para o cliente HTTP
-    *is_on = !(*is_on);
-    free_http_client(client);
-    return;
-}
 
 bool watch_buttons(int BUTTON_PIN){
     if (gpio_get(BUTTON_PIN) == 0) {
@@ -125,7 +58,8 @@ void send_colors_toggle(int* count, Color* current_color) {
         return;
     }
     char json_body[512];
-    snprintf(json_body, sizeof(json_body),
+    if(count == -1){
+        snprintf(json_body, sizeof(json_body),
         "{"
         "  \"red\": %d,"
         "  \"green\": %d,"
@@ -134,8 +68,21 @@ void send_colors_toggle(int* count, Color* current_color) {
         "    { \"name\": \"White Lamp\", \"toggle\": true, \"bright_mul\": 1.0 },"
         "    { \"name\": \"bulb2\", \"toggle\": false, \"bright_mul\": 1.0 }"
         "  ]"
-        "}", COLORS[*count].red, COLORS[*count].green, COLORS[*count].blue
+        "}", (*current_color).red, (*current_color).green, (*current_color).blue
         );
+    } else {
+        snprintf(json_body, sizeof(json_body),
+            "{"
+            "  \"red\": %d,"
+            "  \"green\": %d,"
+            "  \"blue\": %d,"
+            "  \"toggles\": ["
+            "    { \"name\": \"White Lamp\", \"toggle\": true, \"bright_mul\": 1.0 },"
+            "    { \"name\": \"bulb2\", \"toggle\": false, \"bright_mul\": 1.0 }"
+            "  ]"
+            "}", COLORS[*count].red, COLORS[*count].green, COLORS[*count].blue
+            );
+    }    
     add_header(client, "Content-Type", "application/json");
     printf("Corpo da requisição: %s\n", json_body);
     add_post(client, json_body);
@@ -158,15 +105,8 @@ void send_colors_toggle(int* count, Color* current_color) {
     return;
 }
 
-void send_turn(int* count) {
-    // Tamanho para a URL
-    if ((*count) > 0)
-        (*count) = 0;
-    else if ((*count) == 0)
-    {   
-        (*count) = 1;
-    }
-    
+void send_turn(bool state) {
+    // Tamanho para a URL    
     char url[256];  
     snprintf(url, sizeof(url), "http://%s:%s%s", HTTP_SERVER_IP, HTTP_SERVER_PORT, "/set_power");
     printf("URL: %s\n", url);
@@ -184,7 +124,7 @@ void send_turn(int* count) {
         "    { \"name\": \"Black Lamp\", \"toggle\": false }"
         "  ]"
         "}",
-        *count ? "true" : "false");
+        (state) ? "true" : "false");
     add_header(client, "Content-Type", "application/json");
     printf("Corpo da requisição: %s\n", json_body);
     add_post(client, json_body);
@@ -194,13 +134,12 @@ void send_turn(int* count) {
         printf("Requisição PUT bem-sucedida! Código de status: %d\n", response.code);
     else {
         printf("Erro na requisição PUT. Código de status: %d\n", response.code);
-        *count--;
-        if (*count == 0)
-            *count++;
     }
     // Libera os recursos alocados para o cliente HTTP
     free_http_client(client);
     return;
 }
 
-
+int adc_to_color(int x) {
+    return (int)round((255.0 * (x - 25)) / 4055);
+    }

--- a/main/functions.h
+++ b/main/functions.h
@@ -3,13 +3,9 @@
 
 #include "colors.h"
 
-void start_display();
-void start_http_server(void);
 bool verify_connection_wifi();
-void create_http_response(void);
-void turn_on_led();
-void send_toggle(bool*);
 void send_colors_toggle(int* count, Color* current_color);
 bool watch_buttons(int BUTTON_PIN);
-void send_turn(int* count);
+void send_turn(bool state);
+int adc_to_color(int valor);
 #endif // FUNCTIONS_H

--- a/main/main.c
+++ b/main/main.c
@@ -240,8 +240,9 @@ void stick(){
 }
 
 int main() {
-  stdio_init_all();  // Inicializa a saída padrão
   adc_init();
+  // Inicializa a saída padrão
+  stdio_init_all();  
   set_peripherals();
   start_display();
   setup_pwm();
@@ -275,6 +276,26 @@ int main() {
         last_color = current_color;
         set_led_color(current_color);
         printf("\nSetting color.");
+      }
+      else{
+        if ((watch_buttons(BUTTON1_PIN)) && (watch_buttons(BUTTON2_PIN))){
+          printf("\nSetting color.");
+          if (watch_buttons(BUTTON1_PIN))
+          {
+            adc_select_input(0);
+            uint adc_x_raw = adc_read();
+            Color color = {adc_x_raw/0.06375, current_color.green, current_color.blue};
+          }
+          if (watch_buttons(BUTTON2_PIN))
+          {
+            adc_select_input(1);
+            uint adc_y_raw = adc_read();
+          }
+          if (watch_buttons(BUTTONSTICK_PIN))
+          {
+            
+          }   
+
       }
   }
   // Desliga Wi-Fi 

--- a/main/main.c
+++ b/main/main.c
@@ -258,6 +258,7 @@ int main() {
         printf("\nSetting color.");
         Color color = {0,0,0};
         int color_choice = 0;
+        
         while (select){
           while(color_choice == 0){
             if (watch_buttons(BUTTON1_PIN)){

--- a/main/main.c
+++ b/main/main.c
@@ -202,12 +202,14 @@ void verify_connection(bool *is_conected, int* count_color, int is_bulb_on, bool
 }
 
 int main() {
+  //Setup
   adc_init();
   stdio_init_all();  
   set_peripherals();
   start_display();
   setup_pwm();
 
+  //Initial Variables
   bool is_conected = false;
   bool is_bulb_on = true;
   bool is_first_time = true;
@@ -223,7 +225,10 @@ int main() {
 
     // Mantem o Wi-Fi ativo
     cyw43_arch_poll();  
+    
+    // Controle quando a Lampada está Ligada
     if (is_bulb_on){
+      // Desligar a lampada
       if (watch_buttons(BUTTON1_PIN)){
         printf("\nBotão 1 pressionado.");
         is_bulb_on = false;
@@ -233,17 +238,21 @@ int main() {
         send_colors_toggle(&count_color, &current_color);
         count_color--;
       }
+      // Trocar cor
       if (watch_buttons(BUTTON2_PIN)){
         send_colors_toggle(&count_color, &current_color);
         printf("%i, %i, %i", current_color.red, current_color.green, current_color.blue);
       }
     }
+    // Mudar a cor da placa para a cor da lampada
     if (!(last_color.blue == current_color.blue && last_color.green == current_color.green && last_color.red == current_color.red)){
       last_color = current_color;
       set_led_color(current_color);
       printf("\nChanging  Color on board.");
     }
+    // Controle de estado quando a lampada está desligada
     if(!is_bulb_on){
+      // Selecionar cor customizada
       if ((watch_buttons(BUTTONSTICK_PIN))){
         bool select = true;
         printf("\nSetting color.");
@@ -294,6 +303,7 @@ int main() {
           }
         }
       }
+      // Ligar Lampada
       if (watch_buttons(BUTTON1_PIN)){
         send_turn(&count_color);
         is_bulb_on = true;


### PR DESCRIPTION
This pull request includes significant updates to the `main/functions.c` and `main/main.c` files, focusing on removing redundant functions, improving the button handling logic, and adding new functionalities for color selection and LED control.

### Codebase simplification:
* [`main/functions.c`](diffhunk://#diff-e644575498a144ffd8717feca6c7de251f33f17171ee014ad5714ec694986939L21-L51): Removed the `monitor_buttons` and `send_toggle` functions, which were no longer needed. [[1]](diffhunk://#diff-e644575498a144ffd8717feca6c7de251f33f17171ee014ad5714ec694986939L21-L51) [[2]](diffhunk://#diff-e644575498a144ffd8717feca6c7de251f33f17171ee014ad5714ec694986939L65-L101)
* [`main/functions.h`](diffhunk://#diff-1ad402de7fd4ec32c03b9c6af8244358f63de6ad7ba6f3ff8a45e2856bdec62bL6-R10): Updated function declarations to reflect the removal of `send_toggle` and changes in `send_turn`.

### New functionalities:
* [`main/functions.c`](diffhunk://#diff-e644575498a144ffd8717feca6c7de251f33f17171ee014ad5714ec694986939L197-R145): Added a new function `adc_to_color` to convert ADC values to color intensity.
* [`main/main.c`](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6L212-L280): Implemented a new feature to allow custom color selection using button presses and ADC input.

### Refactoring:
* [`main/functions.c`](diffhunk://#diff-e644575498a144ffd8717feca6c7de251f33f17171ee014ad5714ec694986939R61-R73): Modified `send_colors_toggle` to handle a special case where `count` is -1.
* [`main/functions.c`](diffhunk://#diff-e644575498a144ffd8717feca6c7de251f33f17171ee014ad5714ec694986939L161-L169): Refactored `send_turn` to use a boolean `state` parameter instead of `count`.

### Code cleanup:
* [`main/main.c`](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6L134-R135): Removed commented-out code and cleaned up the `set_peripherals` and `verify_connection` functions for better readability. [[1]](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6L134-R135) [[2]](diffhunk://#diff-2978fe1c2c45b4eca89dc476376ddc7193bc4e5e7fff0c7d1c465f057b35a5e6L212-L280)